### PR TITLE
Update to AKI version 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "main": "src/messages.js",
     "license": "MIT",
     "author": "KittehKun",
-    "akiVersion": "3.1.1",
+    "akiVersion": "3.2.1",
     "scripts": {
         "setup:environment": "npm i",
         "build:unzipped": "copyfiles -e \"./node_modules/**/*.*\" -e \"./dist/**/*.*\" -e \"./package-lock.json\" -e \"./tsconfig.json\" -e \"./README.txt\" -e \"./mod.code-workspace\" \"./**/*.*\" ./dist",

--- a/src/messages.js
+++ b/src/messages.js
@@ -15,7 +15,7 @@ class Mod {
         const logger = container.resolve("WinstonLogger"); //Get the logger from the server container
         const databaseServer = container.resolve("DatabaseServer");
         //Functions
-        logger.logWithColor("Loading: ~| Kitteh's Welcome Messages |~", LogTextColor_1.LogTextColor.white); //Notify of mod load
+        logger.info("Loading: ~| Kitteh's Welcome Messages |~"); //Notify of mod load
         //Main Logic
         const tables = databaseServer.getTables(); //Get Database from the Server
         const LOCALES_EN = tables.locales.global.en.interface;


### PR DESCRIPTION
Why use LogWithColor with color white, when you can just do
`
logger.info (+ actually works)
`
//change version according to your mind :P ex. 2.1.1 / 2.2.0
I'm not js specialist but you can fix it and add color
E.g:
`"Tacticool Replacers"` loading color or just do `Logger.log("Loading: ~| Kitteh's Welcome Messages |~", "bold white magentaBG");`